### PR TITLE
Correct the set-membership condition in the predict_set docstring

### DIFF
--- a/src/crepes/base.py
+++ b/src/crepes/base.py
@@ -3718,10 +3718,10 @@ class WrapClassifier():
         prediction sets : ndarray of shape (n_values, n_classes) or list
             prediction sets, where the value 1 (0) in the binary array
             indicates that the class label is included (excluded), i.e.,
-            the corresponding p-value is less than 1-confidence; if
-            labels=True or a list/array of labels, the output is a list
-            of length n_values, where each element is a list of up to
-            n_classes labels
+            the corresponding p-value is greater than or equal to
+            1-confidence; if labels=True or a list/array of labels, the
+            output is a list of length n_values, where each element is a
+            list of up to n_classes labels
 
         Examples
         --------


### PR DESCRIPTION
Fixes #46.

The `Returns` section of `WrapClassifier.predict_set` says a class label is included when "the corresponding p-value is less than 1-confidence". Every site that builds a prediction set computes `(p_values >= 1-confidence)`, so the condition is the opposite: a label is included when its p-value is greater than or equal to `1-confidence`.

Documentation only, no behaviour change. Line 3721 is the only place in `base.py` that states the direction of the comparison, so there is nothing else for a reader to check it against; someone re-thresholding raw `predict_p` output as documented gets the complement of the intended sets.

Introduced in 45fd0bd (0.6.0).

Checked on this branch:

```python
>>> import numpy as np
>>> from crepes import ConformalClassifier
>>> cc = ConformalClassifier().fit(np.arange(19)/100)
>>> cc.predict_p(np.array([[0.5, 0.005]]), smoothing=False)
array([[0.05, 0.95]])
>>> cc.predict_set(np.array([[0.5, 0.005]]), confidence=0.9, smoothing=False)
array([[0, 1]])
```

The documented rule predicts `[[1, 0]]`.