### PR TITLE
Warn when the calibration set is too small for the chosen confidence level

### DIFF
--- a/src/crepes/base.py
+++ b/src/crepes/base.py
@@ -337,6 +337,8 @@ class ConformalClassifier(ConformalPredictor):
             seed = self.seed
         p_values = p_values_batch(self.alphas, alphas, self.bins, bins,
                                   smoothing, seed)
+        check_calibration_size(self.alphas, self.bins, bins, confidence,
+                               smoothing)
         prediction_sets = (p_values >= 1-confidence).astype(int)
         if labels is not None:
             prediction_sets = [list(labels[s]) for s in prediction_sets.astype(bool)]
@@ -517,7 +519,9 @@ class ConformalClassifier(ConformalPredictor):
         if not online:
             p_values = self.predict_p(alphas, bins, True, classes, y,
                                       smoothing, seed)
-            prediction_sets = (p_values >= 1-confidence).astype(int)        
+            check_calibration_size(self.alphas, self.bins, bins, confidence,
+                                   smoothing)
+            prediction_sets = (p_values >= 1-confidence).astype(int)
         else:
             p_values = self.predict_p_online(alphas, classes, y, bins, True,
                                              smoothing, seed, warm_start)
@@ -552,6 +556,33 @@ def get_classification_results(prediction_sets, p_values, classes, y, metrics):
                                                   class_indexes],
                                          "uniform").pvalue
     return test_results
+
+def check_calibration_size(alphas_cal, bins_cal, bins_test, confidence,
+                           smoothing):
+    if smoothing:
+        return
+    if type(bins_cal) == list:
+        bins_cal = np.array(bins_cal)
+    if bins_cal is None:
+        if 1/(len(alphas_cal)+1) >= 1-confidence:
+            warnings.warn("the no. of calibration examples is too small " \
+                          "for the chosen confidence level; the " \
+                          "prediction sets will be of maximum size")
+    else:
+        bin_values = np.unique(bins_cal if bins_test is None else bins_test)
+        too_small_bins = [b for b in bin_values
+                          if 1/(np.sum(bins_cal == b)+1) >= 1-confidence]
+        if len(too_small_bins) > 0:
+            if len(too_small_bins) < 11:
+                bins_to_show = " ".join([str(b) for b in too_small_bins])
+            else:
+                bins_to_show = " ".join([str(b) for b in
+                                         too_small_bins[:10]]+['...'])
+            warnings.warn("the no. of calibration examples is too " \
+                          "small for the chosen confidence level " \
+                          f"in the following bins: {bins_to_show}; " \
+                          "the corresponding prediction sets will be of " \
+                          "maximum size")
 
 class ConformalRegressor(ConformalPredictor):
     """
@@ -3907,6 +3938,9 @@ class WrapClassifier():
             np.random.seed(seed)
         p_values = self.predict_p(X, y, True, smoothing, seed, online,
                                   warm_start)
+        if not online:
+            check_calibration_size(self.cc.alphas, self.cc.bins, None,
+                                   confidence, smoothing)
         prediction_sets = (p_values >= 1-confidence).astype(int)
         test_results = get_classification_results(prediction_sets,
                                                   p_values,


### PR DESCRIPTION
Fixes #47.

`ConformalRegressor.predict_int` (lines 912, 930) and `ConformalPredictiveSystem.predict` (2387, 2419, 2440, 2484) warn when the calibration set is too small for the requested confidence level and the output degenerates to maximum size. `ConformalClassifier` has the same failure mode and no warning.

With `smoothing=False` the smallest attainable p-value is `1/(n_cal+1)`, so when `1/(n_cal+1) >= 1-confidence` every class clears the threshold for every test object and every prediction set contains every label. At `confidence=0.95` this is the same 19-example boundary the regressor already warns about, and the existing message reads correctly for the classifier with "sets" in place of "intervals".

This is the failure mode that prompted the v0.2.0 warnings after @Geethen reported it for the regressor.

## What this adds

`check_calibration_size`, placed after `get_classification_results` and mirroring the wording of both existing regressor warnings (plain and Mondrian), called from the batch methods that produce prediction sets:

- `ConformalClassifier.predict_set`
- `ConformalClassifier.evaluate` (batch branch)
- `WrapClassifier.evaluate` (batch branch)

## Scope choices

- **Batch only.** The existing regressor and CPS warnings sit on the batch methods; the online methods on both sides are silent. Warning on the classifier online paths would introduce a new asymmetry, so I left them alone.
- **No-op when `smoothing=True`.** Smoothed p-values can fall arbitrarily close to zero regardless of `n_cal`, so there is nothing to warn about on the default path.
- **Mondrian reports only the bins present in the test set.** This keeps the class-conditional case to one warning per undersized class rather than one per class per call, since `WrapClassifier.predict_set` calls `cc.predict_set` once per class.
- The batch paths of `WrapClassifier.predict_set`, including the class-conditional one, route through `ConformalClassifier.predict_set` and are covered by that call rather than a separate one.

Happy to change any of these — particularly the batch/online scope, if you would rather have the online paths covered too.

## Checked

Script exercising the plain, Mondrian, class-conditional and `WrapClassifier` paths, all passing on this branch:

- `n_cal=18`, non-smoothed: returns `[[1, 1]]` and warns; `n_cal=19`: no warning
- `n_cal=18`, smoothed: no warning
- Mondrian with bins of 18 and 100: only the undersized bin is named
- `WrapClassifier` with `class_cond=True` and 15 per class: fully vacuous sets, one warning per class; `evaluate` warns on the same setup
- default smoothed paths unchanged and silent

I did not add it to the repository since there is no test suite to add it to, but glad to include it if useful.