### PR TITLE
Fix NameError in MondrianCategorizer.apply() when oob=False

### DIFF
--- a/src/crepes/extras.py
+++ b/src/crepes/extras.py
@@ -410,7 +410,7 @@ class MondrianCategorizer():
                 scores = np.array([np.mean(predictions[oob_masks[:,i],i])
                                    for i in range(len(X))])
             else:
-                scores = learner.predict(X)
+                scores = self.learner.predict(X)
             bins = binning(scores, bins=self.bin_thresholds)
         return bins
                 


### PR DESCRIPTION
`MondrianCategorizer.apply()`'s `oob=False` branch reads a bare name `learner`,
which is neither a parameter of `apply()` nor an attribute on the instance —
it is `self.learner`, assigned in `fit()`. The branch therefore raises
`NameError` on every call:

```python
from crepes.extras import MondrianCategorizer
from sklearn.ensemble import RandomForestRegressor

rf = RandomForestRegressor(n_estimators=10, oob_score=True, random_state=0).fit(X, y)
mc = MondrianCategorizer()
mc.fit(X=X, learner=rf, oob=False)   # succeeds
mc.apply(X)                          # NameError: name 'learner' is not defined
```

`oob=False` is `fit()`'s documented default (its own docstring documents the
`learner` parameter), so this is the documented, default combination, not an
edge case. The `oob=True` branch two lines above already reads
`self.learner.estimators_`, so this is the one call site that never picked up
`self.`.

One-line fix: `learner.predict(X)` → `self.learner.predict(X)`. The branch
currently raises unconditionally, so no existing output can change.