### PR TITLE
Fix the non-smoothed online p-value: wrong index and an unassigned name

### DIFF
--- a/src/crepes/base.py
+++ b/src/crepes/base.py
@@ -3052,7 +3052,7 @@ def p_values_online_classification(alphas, classes, y, bins=None,
                      for q in range(len(alphas))])
             else:
                 p_values = np.array(
-                    [np.sum(all_alphas[:start+q+1] >= all_alphas[q])/ \
+                    [np.sum(all_alphas[:start+q+1] >= all_alphas[start+q])/ \
                      (start + q + 1) for q in range(len(alphas))])
     else:
         bin_values, bin_indexes = np.unique(all_bins, return_inverse=True)
@@ -3090,14 +3090,14 @@ def p_values_online_classification(alphas, classes, y, bins=None,
                 bin_alphas = alphas[bin_indexes[start:] == b]
                 bin_start = len(bin_all_alphas) - len(bin_alphas)
                 if all_classes:
-                    p_values_bin = np.array([[
+                    bin_p_values = np.array([[
                         (np.sum(bin_all_alphas[
                             :bin_start+q] >= bin_alphas[q,c]) + 1) \
                         / (bin_start + q + 1)
                         for c in range(bin_alphas.shape[1])]
                                              for q in range(len(bin_alphas))])
                 else:
-                    p_values_bin = np.array([
+                    bin_p_values = np.array([
                         (np.sum(bin_all_alphas[
                             :bin_start+q] >= \
                                 bin_all_alphas[bin_start+q]) + 1) \


### PR DESCRIPTION
Fixes #52.

Two independent one-line fixes in `p_values_online_classification`'s `smoothing=False`
arms; grouped in one PR because they're two lines of the same function, not because they're
related (either could be reverted independently of the other).

**1. `base.py:3055`**: `all_alphas[q]` (calibration element `q`) becomes
`all_alphas[start+q]` (the test point), matching every sibling branch in the function
(`:3042`, `:3044`, `:3050`). No `+1` added to the numerator: `all_alphas[start+q]` is the
last element of the `[:start+q+1]` window and already counts itself.

**2. `base.py:3093` and `:3100`**: `p_values_bin` becomes `bin_p_values`, matching the name
`:3107` reads and the five other accumulate blocks in the file that already use it
(`:2943`, `:2963`, `:3086`, `:3297`, `:3309`). Both branches raised `UnboundLocalError`
unconditionally before this fix.

Verified both directions with the reproductions in #52: the first fix flips the
monotonicity-sweep table from inverted to correct, and the second turns the
`UnboundLocalError` into a normal return across `predict_p_online`, `predict_set_online`,
and `evaluate(online=True)`, both `all_classes` settings. No existing output can change for
fix 2, since that branch raised 100% of the time before it.